### PR TITLE
Update commons-io dependency to version 2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>1.4</version>
+        <version>2.4</version>
       </dependency>
       
       <dependency>


### PR DESCRIPTION
There seems to be a conflict between jenkins and its plugins in respect of the commons-io lib.

Further information can be found here:
https://issues.jenkins-ci.org/browse/JENKINS-26923

And here:
http://stackoverflow.com/questions/28275375/jenkins-using-the-wrong-commons-io

I propose to upgrade the version